### PR TITLE
switch to new CircleCI go sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
+	github.com/kelvintaywl/circleci-go-sdk v0.1.0
 	github.com/kelvintaywl/circleci-webhook-go-sdk v1.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/kelvintaywl/circleci-go-sdk v0.1.0 h1:8nLYvJ8J+UwScULL9aglMB/0bq011WBrnn9lmeAbXhA=
+github.com/kelvintaywl/circleci-go-sdk v0.1.0/go.mod h1:1KA8J0ENqWbkMzRaJ6/fxeoEbTRbdPd+vtGWJGaN7Sk=
 github.com/kelvintaywl/circleci-webhook-go-sdk v1.0.0 h1:8bt8FTXkAdM27q63nr/x4YN5y8LHTVFZd5sLRMy1DH0=
 github.com/kelvintaywl/circleci-webhook-go-sdk v1.0.0/go.mod h1:vxQQhgGRgA1xRlm3JKwgbtwrmfKy4lo2i3WQaxaIxnM=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	api "github.com/kelvintaywl/circleci-webhook-go-sdk/client"
+	api "github.com/kelvintaywl/circleci-go-sdk/client"
 )
 
 // Ensure CircleciProvider satisfies various provider interfaces.

--- a/internal/provider/webhook_resource.go
+++ b/internal/provider/webhook_resource.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/kelvintaywl/circleci-webhook-go-sdk/client/webhook"
-	"github.com/kelvintaywl/circleci-webhook-go-sdk/models"
+	"github.com/kelvintaywl/circleci-go-sdk/client/webhook"
+	"github.com/kelvintaywl/circleci-go-sdk/models"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces

--- a/internal/provider/webhooks_data_source.go
+++ b/internal/provider/webhooks_data_source.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/kelvintaywl/circleci-webhook-go-sdk/client/webhook"
+	"github.com/kelvintaywl/circleci-go-sdk/client/webhook"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces


### PR DESCRIPTION
This PR switches the Go SDK dependency to the newer [github.com/kelvintayw/circleci-go-sdk](https://github.com/kelvintaywl/circleci-go-sdk/tree/main/client) which handles both the scheduled pipelines & webhooks API.

This is in preparation for supporting scheduled pipelines as resources.
Part of addressing #10