### PR TITLE
Update circleci-go-sdk to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/kelvintaywl/circleci-go-sdk v0.1.0
+	github.com/kelvintaywl/circleci-go-sdk v0.1.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/kelvintaywl/circleci-go-sdk v0.1.0 h1:8nLYvJ8J+UwScULL9aglMB/0bq011WBrnn9lmeAbXhA=
-github.com/kelvintaywl/circleci-go-sdk v0.1.0/go.mod h1:1KA8J0ENqWbkMzRaJ6/fxeoEbTRbdPd+vtGWJGaN7Sk=
+github.com/kelvintaywl/circleci-go-sdk v0.1.2 h1:KAiWemrX9+IPXP2T1vNhqwObC+HRkcjKxaWotKaD9DA=
+github.com/kelvintaywl/circleci-go-sdk v0.1.2/go.mod h1:1KA8J0ENqWbkMzRaJ6/fxeoEbTRbdPd+vtGWJGaN7Sk=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=


### PR DESCRIPTION
The newer CircleCI Go SDK v0.1.2 comes with support for project env vars