### PR TITLE
Refactor: improving developer experience

### DIFF
--- a/docs/resources/checkout_key.md
+++ b/docs/resources/checkout_key.md
@@ -25,6 +25,13 @@ Otherwise, the CircleCI API will return a HTTP 500.
 Please see the CircleCI support article below for more information:
 https://support.circleci.com/hc/en-us/articles/360006975013-Troubleshooting-An-internal-server-error-occurred-Create-User-Keys-with-the-API
 
+## Deleting keys
+
+When using `terraform destroy`, please note that only the private key on CircleCI is deleted.
+
+The public key stored on your VCS provider (e.g., GitHub) is not deleted.
+Please delete the public key on the VCS provider side accordingly.
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/context_env_var.md
+++ b/docs/resources/context_env_var.md
@@ -49,6 +49,6 @@ resource "circleci_context_env_var" "test_envvar" {
 
 ### Read-Only
 
-- `created_at` (String) The date and time the schedule was created
+- `created_at` (String) The date and time the context environment variable was created
 - `id` (String) Read-only unique identifier, set as {context_id}/{name}
-- `updated_at` (String) The date and time the schedule was last updated
+- `updated_at` (String) The date and time the context environment variable was last updated

--- a/internal/provider/checkout_key_resource.go
+++ b/internal/provider/checkout_key_resource.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/kelvintaywl/circleci-go-sdk/client/project"
 	"github.com/kelvintaywl/circleci-go-sdk/models"
 )
@@ -246,6 +244,9 @@ func (r *CheckoutKeyResource) Delete(ctx context.Context, req resource.DeleteReq
 		)
 		return
 	}
-	cleanupMsg := "Only the private key is deleted on CircleCI. You would want to delete the public key on the VCS side (e.g., GitHub)"
-	tflog.Warn(ctx, cleanupMsg)
+	// so that users are aware of required follow-up.
+	resp.Diagnostics.AddWarning(
+		"Only the private key is deleted on CircleCI.",
+		"You would want to delete the public key on the VCS side (e.g., GitHub).",
+	)
 }

--- a/internal/provider/checkout_key_resource.go
+++ b/internal/provider/checkout_key_resource.go
@@ -190,6 +190,12 @@ func (r *CheckoutKeyResource) Create(ctx context.Context, req resource.CreateReq
 			"Error creating project checkout key",
 			fmt.Sprintf("Could not create project checkout key, unexpected error: %s", err.Error()),
 		)
+		if keyType == "user-key" {
+			resp.Diagnostics.AddWarning(
+				"Ensure you have authorized with GitHub",
+				"See https://support.circleci.com/hc/en-us/articles/360006975013",
+			)
+		}
 		return
 	}
 

--- a/internal/provider/context_env_var_resource.go
+++ b/internal/provider/context_env_var_resource.go
@@ -53,7 +53,7 @@ func (r *ContextEnvVarResource) Schema(_ context.Context, _ resource.SchemaReque
 				},
 			},
 			"created_at": schema.StringAttribute{
-				MarkdownDescription: "The date and time the schedule was created",
+				MarkdownDescription: "The date and time the context environment variable was created",
 				Computed:            true,
 				// unchanged even during updates
 				PlanModifiers: []planmodifier.String{
@@ -61,7 +61,7 @@ func (r *ContextEnvVarResource) Schema(_ context.Context, _ resource.SchemaReque
 				},
 			},
 			"updated_at": schema.StringAttribute{
-				MarkdownDescription: "The date and time the schedule was last updated",
+				MarkdownDescription: "The date and time the context environment variable was last updated",
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{

--- a/templates/resources/checkout_key.md.tmpl
+++ b/templates/resources/checkout_key.md.tmpl
@@ -25,6 +25,13 @@ Otherwise, the CircleCI API will return a HTTP 500.
 Please see the CircleCI support article below for more information:
 https://support.circleci.com/hc/en-us/articles/360006975013-Troubleshooting-An-internal-server-error-occurred-Create-User-Keys-with-the-API
 
+## Deleting keys
+
+When using `terraform destroy`, please note that only the private key on CircleCI is deleted.
+
+The public key stored on your VCS provider (e.g., GitHub) is not deleted.
+Please delete the public key on the VCS provider side accordingly.
+
 ## Example Usage
 
 {{ tffile "examples/resources/checkout_key/resource.tf" }}


### PR DESCRIPTION
This PR refactors the following:

- explicitly warn about need for GitHub OAuth authorization if not done, for creating user-type checkout keys
- explicitly warn about need to delete public keys on VCS after checkout keys are deleted; closes #29 
- fix schema description on context environment variables