### PR TITLE
chore: ignore 404 but log at WARN level

### DIFF
--- a/internal/provider/context_resource.go
+++ b/internal/provider/context_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 
@@ -228,9 +229,14 @@ func (r *ContextResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	_, err := r.client.Client.Contexts.DeleteContext(param, r.client.Auth)
 	if err != nil {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "not found") {
+			tflog.Warn(ctx, fmt.Sprintf("Context no longer found: %s", id))
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error deleting project env var",
-			fmt.Sprintf("Could not delete context %s, unexpected error: %s", id, err.Error()),
+			fmt.Sprintf("Could not delete context %s, unexpected error: %s", id, errMsg),
 		)
 		return
 	}


### PR DESCRIPTION
This PR closes #31 , by catching HTTP 404s from API client when destroying the resource.

The catch logic itself is really not ideal;
I would have preferred to cast the `err` and check its status code as 404 specifically.
However, with my limited knowledge on Golang, i went with looking for the `not found` substring returned in the `err.Error()` string.

Not ideal indeed, but I think this can be improved later. 