### PR TITLE
refactor: move acceptance test project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ jobs:
             OS: linux
             ARCH: amd64
       - run:
+          name: Debug CircleCI user
+          command: |
+            curl -H "Circle-Token: $CIRCLE_TOKEN" https://circleci.com/api/v2/me | jq .
+      - run:
           name: Run acceptance tests
           command: make testacc
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # (Unofficial) Terraform Provider for CircleCI
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/kelvintaywl-cci/terraform-provider-circleci/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/kelvintaywl-cci/terraform-provider-circleci/tree/main)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/kelvintaywl/terraform-provider-circleci/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/kelvintaywl/terraform-provider-circleci/tree/main)
 
 ## Usage
 
@@ -64,7 +64,7 @@ $ make tf.destroy
 ## Testing
 
 This uses a dummy CircleCI project for acceptance tests:
-https://github.com/kelvintaywl-cci/tf-provider-acceptance-test-dummy
+https://github.com/kelvintaywl-tf/tf-provider-acceptance-test-dummy
 
 ```console
 # Run acceptance tests

--- a/internal/provider/checkout_keys_data_source_test.go
+++ b/internal/provider/checkout_keys_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccCheckoutKeysDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				// github/kelvintaywl-cci/tf-provider-acceptance-test-dummy
+				// github/kelvintaywl-tf/tf-provider-acceptance-test-dummy
 				Config: providerConfig + fmt.Sprintf(`
 data "circleci_checkout_keys" "keys" {
   project_slug = "%s"

--- a/internal/provider/context_data_source_test.go
+++ b/internal/provider/context_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccContextDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				// github/kelvintaywl-cci/tf-provider-acceptance-test-dummy
+				// github/kelvintaywl-tf/tf-provider-acceptance-test-dummy
 				Config: providerConfig + fmt.Sprintf(`
 data "circleci_context" "test" {
   name = "%s"

--- a/internal/provider/project_data_source_test.go
+++ b/internal/provider/project_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccProjectDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				// github/kelvintaywl-cci/tf-provider-acceptance-test-dummy
+				// github/kelvintaywl-tf/tf-provider-acceptance-test-dummy
 				Config: providerConfig + fmt.Sprintf(`
 data "circleci_project" "dummy" {
   slug = "%s"
@@ -22,11 +22,11 @@ data "circleci_project" "dummy" {
 					resource.TestCheckResourceAttr("data.circleci_project.dummy", "id", projectId),
 					resource.TestCheckResourceAttr("data.circleci_project.dummy", "slug", projectSlug),
 
-					resource.TestCheckResourceAttr("data.circleci_project.dummy", "organization_name", "kelvintaywl-cci"),
-					resource.TestCheckResourceAttr("data.circleci_project.dummy", "organization_slug", "gh/kelvintaywl-cci"),
+					resource.TestCheckResourceAttr("data.circleci_project.dummy", "organization_name", "kelvintaywl-tf"),
+					resource.TestCheckResourceAttr("data.circleci_project.dummy", "organization_slug", "gh/kelvintaywl-tf"),
 					resource.TestCheckResourceAttrSet("data.circleci_project.dummy", "organization_id"),
 
-					resource.TestCheckResourceAttr("data.circleci_project.dummy", "vcs_url", "https://github.com/kelvintaywl-cci/tf-provider-acceptance-test-dummy"),
+					resource.TestCheckResourceAttr("data.circleci_project.dummy", "vcs_url", "https://github.com/kelvintaywl-tf/tf-provider-acceptance-test-dummy"),
 					resource.TestCheckResourceAttr("data.circleci_project.dummy", "vcs_default_branch", "main"),
 					resource.TestCheckResourceAttr("data.circleci_project.dummy", "vcs_provider", "GitHub"),
 				),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -16,17 +16,17 @@ provider "circleci" {
   hostname = "circleci.com"
 }
 `
-	// project name: github/kelvintaywl-cci/tf-provider-acceptance-test-dummy
+	// project name: github/kelvintaywl-tf/tf-provider-acceptance-test-dummy
 	projectId   string = "c124cca6-d03e-4733-b84d-32b02347b78c"
-	projectSlug string = "github/kelvintaywl-cci/tf-provider-acceptance-test-dummy"
+	projectSlug string = "github/kelvintaywl-tf/tf-provider-acceptance-test-dummy"
 	// webhook name: added-via-ui
 	webhookId string = "8ed03fd1-5426-4138-a27d-aec0328c39fb"
 
-	// org slug: github/kelvintaywl-cci
-	orgId string = "7f284df8-ac74-42d5-9fad-ab23f731e475"
+	// org slug: github/kelvintaywl-tf
+	orgId string = "1e846a63-ae07-4549-a548-3db2aa4155e8"
 
-	// context "from_tf" under github/kelvintaywl-cci org
-	contextId   string = "f2baca54-73ea-4cba-b314-3d50d74bef13"
+	// context "from_tf" under github/kelvintaywl-tf org
+	contextId   string = "c050c79f-f03b-4060-80b9-2562c7fdaa5c"
 	contextName string = "from_tf"
 )
 

--- a/internal/provider/webhooks_data_source_test.go
+++ b/internal/provider/webhooks_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccWebhooksDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				// github/kelvintaywl-cci/tf-provider-acceptance-test-dummy
+				// github/kelvintaywl-tf/tf-provider-acceptance-test-dummy
 				Config: providerConfig + fmt.Sprintf(`
 data "circleci_webhooks" "test" {
   project_id = "%s"


### PR DESCRIPTION
To isolate the acceptance tests to an org and its project with zero existing usage, I've moved the previous acceptance test project from:

kelvintaywl-cci org -> kelvintaywl-tf org.

As such, this PR corrects the relevant resource IDs after the transfer.