### PR TITLE
fix: use hostname as-is if server

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -119,8 +119,10 @@ func (p *CircleciProvider) Configure(ctx context.Context, req provider.Configure
 	client := api.NewHTTPClientWithConfig(strfmt.Default, cfg)
 	auth := rtc.APIKeyAuth("Circle-Token", "header", apiToken)
 
-	// hardcoded runner subdomain
-	rhostname := fmt.Sprintf("runner.%s", hostname)
+	rhostname := hostname
+	if hostname == defaultHostName {
+		rhostname = fmt.Sprintf("runner.%s", defaultHostName)
+	}
 	rcfg := rapi.DefaultTransportConfig().WithHost(rhostname)
 	rclient := rapi.NewHTTPClientWithConfig(strfmt.Default, rcfg)
 


### PR DESCRIPTION
See https://github.com/CircleCI-Public/circleci-cli/blob/8f735af42a85c9932339f561466fc743a502103a/cmd/runner/runner.go#L25-L29