### PR TITLE
add docs for how to find a runner resource class id

### DIFF
--- a/docs/resources/runner_resource_class.md
+++ b/docs/resources/runner_resource_class.md
@@ -50,7 +50,13 @@ output "runner_from_tf_id" {
 
 ## Import
 
-An existing Runner resource-class can be imported via its namespace/resource_class value, and unique ID (UUID).
+An existing Runner resource-class can be imported via its namespace/resource_class value, and unique ID (UUID). This can be found by calling the `api/v2/runner/resource` endpoint:
+
+```sh
+curl --request GET \
+  --url 'https://runner.circleci.com/api/v2/runner/resource?namespace=<your-namespace>' \
+  --header 'Circle-Token: <your-api-token>' | jq
+```
 
 ```console
 # import a Runner resource-class


### PR DESCRIPTION
I spent more time than I'm willing to admit to find how to get the id from the CCI API. Turns out the endpoints listed in [their docs](https://circleci.com/docs/runner-api/) (which is for v3) doesn't return the id, and I was unable to find the specific endpoint in [the docs for v2](https://circleci.com/docs/api/v2/index.html) either. 

I went on a wild goose chase [from here](https://github.com/kelvintaywl/terraform-provider-circleci/blob/dc60aee311af367997afd3746becd13107b36f60/internal/provider/runner_resource_class_resource.go#L128C50-L145) [to here](https://github.com/kelvintaywl/circleci-runner-go-sdk/blob/64926edb45dff35ddb780fd14b3eae8342dd2fae/client/resource_class/resource_class_client.go#L134-L146) to figure it out... 

I'd like to save as many people as I can from being exposed to this