### PR TITLE
Add support for retries when 429 status codes are received

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,3 +56,5 @@ provider "circleci" {
 
 - `api_token` (String) A CircleCI user API token. This can also be set via the `CIRCLE_TOKEN` environment variable.
 - `hostname` (String) CircleCI hostname (default: circleci.com). This can also be set via the `CIRCLE_HOSTNAME` environment variable.
+- `max_retries` (Number) Maximum number of retries for API calls when retry is enabled (default: 3).
+- `retry` (Boolean) Whether to retry API calls when provider receives an HTTP 429 status code (default: false).

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 
@@ -61,10 +62,36 @@ func (t *httpClientTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	return http.DefaultTransport.RoundTrip(req)
 }
 
+// retryOn429Transport wraps an http.RoundTripper to retry on HTTP 429 responses.
+type retryOn429Transport struct {
+	Base       http.RoundTripper
+	MaxRetries int
+	Backoff    func(attempt int) int // returns milliseconds
+}
+
+func (t *retryOn429Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	attempts := 0
+	for {
+		resp, err := t.Base.RoundTrip(req)
+		if err != nil {
+			return resp, err
+		}
+		if resp.StatusCode != 429 || attempts >= t.MaxRetries {
+			return resp, err
+		}
+		resp.Body.Close()
+		backoffMs := t.Backoff(attempts)
+		time.Sleep(time.Duration(backoffMs) * time.Millisecond)
+		attempts++
+	}
+}
+
 // CircleciProviderModel describes the provider data model.
 type CircleciProviderModel struct {
-	ApiToken types.String `tfsdk:"api_token"`
-	Hostname types.String `tfsdk:"hostname"`
+	ApiToken   types.String `tfsdk:"api_token"`
+	Hostname   types.String `tfsdk:"hostname"`
+	Retry      types.Bool   `tfsdk:"retry"`
+	MaxRetries types.Int64  `tfsdk:"max_retries"`
 }
 
 func (p *CircleciProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -83,6 +110,14 @@ func (p *CircleciProvider) Schema(ctx context.Context, req provider.SchemaReques
 				MarkdownDescription: fmt.Sprintf("CircleCI hostname (default: %s). This can also be set via the `CIRCLE_HOSTNAME` environment variable.", defaultHostName),
 				Optional:            true,
 			},
+			"retry": schema.StringAttribute{
+				MarkdownDescription: "Whether to retry API calls when provider receives an HTTP 429 status code (default: false).",
+				Optional:            true,
+			},
+			"max_retries": schema.Int64Attribute{
+				MarkdownDescription: "Maximum number of retries for API calls when retry is enabled (default: 3).",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -93,6 +128,10 @@ func (p *CircleciProvider) Configure(ctx context.Context, req provider.Configure
 	// Check environment variables
 	apiToken := os.Getenv("CIRCLE_TOKEN")
 	hostname := os.Getenv("CIRCLE_HOSTNAME")
+
+	// Retry settings
+	retry := false
+	maxRetries := int64(3)
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -107,6 +146,14 @@ func (p *CircleciProvider) Configure(ctx context.Context, req provider.Configure
 
 	if data.Hostname.ValueString() != "" {
 		hostname = data.Hostname.ValueString()
+	}
+
+	if data.Retry.ValueBool() {
+		retry = data.Retry.ValueBool()
+	}
+
+	if data.MaxRetries.ValueInt64() > 0 {
+		maxRetries = data.MaxRetries.ValueInt64()
 	}
 
 	if apiToken == "" {
@@ -136,7 +183,25 @@ func (p *CircleciProvider) Configure(ctx context.Context, req provider.Configure
 		rhostname = fmt.Sprintf("runner.%s", defaultHostName)
 	}
 	rcfg := rapi.DefaultTransportConfig().WithHost(rhostname)
-	rclient := rapi.NewHTTPClientWithConfig(strfmt.Default, rcfg)
+
+	var rclient *rapi.Circleci
+	if retry {
+		// Add retry transport for 429s
+		baseTransport := http.DefaultTransport
+		retryTransport := &retryOn429Transport{
+			Base:       baseTransport,
+			MaxRetries: int(maxRetries),
+			Backoff: func(attempt int) int {
+				// Exponential backoff: 500ms, 1000ms, 2000ms
+				return 500 << attempt
+			},
+		}
+		transport := rtc.New(rcfg.Host, rcfg.BasePath, rcfg.Schemes)
+		transport.Transport = retryTransport
+		rclient = rapi.New(transport, strfmt.Default)
+	} else {
+		rclient = rapi.NewHTTPClientWithConfig(strfmt.Default, rcfg)
+	}
 
 	httpClient := &http.Client{Transport: &httpClientTransport{
 		APIToken: apiToken,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -14,6 +14,8 @@ const (
 provider "circleci" {
   // api_token via CIRCLE_TOKEN env var
   hostname = "circleci.com"
+  retry = true
+  max_retries = 4
 }
 `
 	// project name: github/kelvintaywl-tf/tf-provider-acceptance-test-dummy


### PR DESCRIPTION
I was able to validate that the retry logic works properly by using the provider with this sandbox project:
```tf
terraform {
  required_providers {
    circleci = {
      source = "example.com/kelvintaywl/circleci"
    }
  }
}

provider "circleci" {
  retry       = true
  max_retries = 4
}

locals {
  range = range(1, 300)
}

resource "circleci_runner_resource_class" "from_tf" {
  count          = length(local.range)
  resource_class = "icj217/from-tf-${local.range[count.index]}"
  description    = "Test from Terraform"
}

output "runner_id" {
  description = "runner ID"
  value       = circleci_runner_resource_class.from_tf[*].id
}
```

Running two `make tf.plan` in separate terminals (after adding `--lock=false`) yielded the 429 error code, which was caught and retried successfully:
```
[0m[1mcircleci_runner_resource_class.from_tf[29]: Refreshing state... [id=f4547a0f-662a-49e8-a102-84f0698ba68d][0m
[0m[1mcircleci_runner_resource_class.from_tf[269]: Refreshing state... [id=370aae82-0791-4faf-a1a3-b54be6eedfc9][0m
[0m[1mcircleci_runner_resource_class.from_tf[192]: Refreshing state... [id=244345f1-4c67-4155-9bdb-d0f7bce1bdf0][0m
[0m[1mcircleci_runner_resource_class.from_tf[63]: Refreshing state... [id=e4826b03-67e4-4877-8c9d-f417d4753ef9][0m
2025-05-28T11:09:31.206-0400 [INFO]  provider.terraform-provider-circleci_v0.0.1: Received HTTP 429, retrying in 500 ms (attempt 1/4): @module=circleci tf_resource_type=circleci_runner_resource_class tf_rpc=ReadResource @caller=/Users/craig.burdulis/Repositories/icj217/terraform-provider-circleci/internal/provider/provider.go:84 tf_provider_addr=registry.terraform.io/kelvintaywl/circleci tf_req_id=02abf5a8-742a-2010-b824-747e358ce410 timestamp=2025-05-28T11:09:31.206-0400
[0m[1mcircleci_runner_resource_class.from_tf[259]: Refreshing state... [id=b23e4cde-124d-4a57-8bb3-3cb06a27b0b9][0m
[0m[1mcircleci_runner_resource_class.from_tf[272]: Refreshing state... [id=a4615019-e7f0-4307-a185-382efaf2b60a][0m
...
```