### PR TITLE
Support imports for projects and checkout keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ The rest of the README is mainly focused on how to develop on this source code.
 | Runner Resource-Classes | Done :white_check_mark: | |
 | Runner Tokens | Done :white_check_mark: | |
 
-| Resource | Status | Import supported? |
-| --- | --- | --- |
-| Webhook | Done :white_check_mark: | :white_check_mark: |
-| Schedule | Done :white_check_mark: | :white_check_mark: |
-| Project | Done :white_check_mark: | |
-| Project Environment Variable | Done :white_check_mark: | |
-| Checkout key | Done :white_check_mark: | |
-| Context | Done :white_check_mark: | :white_check_mark: |
-| Context Environment variable | Done :white_check_mark: | |
-| Runner Resource-class | Done :white_check_mark: | :white_check_mark: |
-| Runner Token | Done :white_check_mark: | |
+| Resource                     | Status                  | Import supported?  |
+| ---                          | ---                     | ---                |
+| Webhook                      | Done :white_check_mark: | :white_check_mark: |
+| Schedule                     | Done :white_check_mark: | :white_check_mark: |
+| Project                      | Done :white_check_mark: | :white_check_mark: |
+| Project Environment Variable | Done :white_check_mark: |                    |
+| Checkout key                 | Done :white_check_mark: | :white_check_mark: |
+| Context                      | Done :white_check_mark: | :white_check_mark: |
+| Context Environment variable | Done :white_check_mark: |                    |
+| Runner Resource-class        | Done :white_check_mark: | :white_check_mark: |
+| Runner Token                 | Done :white_check_mark: |                    |
 
 ## Examples
 

--- a/docs/resources/checkout_key.md
+++ b/docs/resources/checkout_key.md
@@ -63,3 +63,12 @@ output "deploy_key_fingerprint" {
 - `id` (String) Read-only unique identifier: uses fingerprint
 - `preferred` (Boolean) A boolean value that indicates if this key is preferred
 - `public_key` (String) A public SSH key
+
+## Import
+
+An existing checkout key can be imported using the project slug and key
+fingerprint, separated by a comma (`,`).
+
+```console
+$ terraform import circleci_checkout_key.deploy_key "<VCS>/<ORG>/<REPO>,<FINGERPRINT>"
+```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -57,3 +57,11 @@ output "vcs_url" {
 - `vcs_default_branch` (String) Default branch of this project
 - `vcs_provider` (String) VCS provider (either GitHub, Bitbucket or CircleCI)
 - `vcs_url` (String) URL to the repository hosting the project's code
+
+## Import
+
+An existing project can be imported via its slug.
+
+```console
+$ terraform import circleci_project.my_project "<VCS>/<ORG>/<REPO>"
+```

--- a/internal/provider/checkout_key_resource.go
+++ b/internal/provider/checkout_key_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -258,4 +259,18 @@ func (r *CheckoutKeyResource) Delete(ctx context.Context, req resource.DeleteReq
 		"Only the private key is deleted on CircleCI.",
 		"You would want to delete the public key on the VCS side (e.g., GitHub).",
 	)
+}
+
+func (r *CheckoutKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	idParts := strings.Split(req.ID, ",")
+
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: project_slug,fingerprint. Got: %q", req.ID),
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_slug"), idParts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("fingerprint"), idParts[1])...)
 }

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -205,4 +206,8 @@ func (r *ProjectResource) Update(ctx context.Context, req resource.UpdateRequest
 func (r *ProjectResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// not implemented; not possible to delete project
 	tflog.Warn(ctx, "Project cannot be deleted via this provider.")
+}
+
+func (r *ProjectResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("slug"), req, resp)
 }

--- a/templates/resources/checkout_key.md.tmpl
+++ b/templates/resources/checkout_key.md.tmpl
@@ -39,3 +39,12 @@ Please delete the public key on the VCS provider side accordingly.
 {{ tffile "examples/resources/checkout_key/resource.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+An existing checkout key can be imported using the project slug and key
+fingerprint, separated by a comma (`,`).
+
+```console
+$ terraform import circleci_checkout_key.deploy_key "<VCS>/<ORG>/<REPO>,<FINGERPRINT>"
+```

--- a/templates/resources/project.md.tmpl
+++ b/templates/resources/project.md.tmpl
@@ -23,3 +23,11 @@ When you run `terraform destroy`, it will not destroy the project on CircleCI.
 {{ tffile "examples/resources/project/resource.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+An existing project can be imported via its slug.
+
+```console
+$ terraform import circleci_project.my_project "<VCS>/<ORG>/<REPO>"
+```


### PR DESCRIPTION
This will allow importing of CircleCI projects and checkout keys.

We tested this in a private organization on about 50 repos using OpenTofu and successfully imported the projects and keys for them.

<details><summary>Exmaple OpenTofu code for importing keys</summary>

```hcl
data "circleci_checkout_keys" "keys" {
  for_each     = local.repos
  project_slug = "github/${local.org}/${each.key}"
}

locals {
  preferred_keys = {
    for k, v in data.circleci_checkout_keys.keys :
    k => [for key in v.keys : key.fingerprint if key.preferred][0]
  }
}

import {
  for_each = local.repos
  id       = "github/${local.org}/${each.key}"
  to       = circleci_project.default[each.key]
}

import {
  for_each = local.preferred_keys
  id       = "github/${local.org}/${each.key},${each.value}"
  to       = circleci_checkout_key.default[each.key]
}
```
</details>